### PR TITLE
[fix] parse release names instead of just the tag names to manage sub releases

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -65,3 +65,11 @@ jobs:
           command: mvnd -v
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: asdf_plugin_test
+        uses: asdf-vm/actions/plugin-test@v1
+        with:
+          command: mvnd -v
+          # version named differently than the tag
+          version: 1.0-m6-m39
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/install
+++ b/bin/install
@@ -27,7 +27,7 @@ installer() {
   local architecture
   case "$(uname -m)" in
     x86_64) architecture="amd64" ;;
-    arm64) 
+    arm64)
       if [[ "$platform" = "darwin" ]]; then
         architecture="aarch64"
         if ! curl --silent --fail -IL "$(github_download_url "$artifact_name" "$version" "$platform" "$architecture")" > /dev/null ; then
@@ -64,7 +64,16 @@ github_download_url() {
   local version=$2
   local platform=$3
   local architecture=$4
-  echo "https://github.com/apache/maven-mvnd/releases/download/${version}/${artifact_name}-${version}-${platform}-${architecture}.zip"
+
+  readonly releases_path="https://api.github.com/repos/apache/maven-mvnd/releases"
+  cmd="curl -Ls"
+  if [ -n "$GITHUB_API_TOKEN" ]; then
+    cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+  fi
+  cmd="$cmd $releases_path"
+
+  eval "$cmd" | grep -oE '"browser_download_url" *: *"[^"]+\/'${artifact_name}'-'${version}'-'${platform}'-'${architecture}'\.zip"' |sed -E 's/"browser_download_url" *: *"(.*)"/\1/' | head -1
+
 }
 
 apache_download_url() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-readonly releases_path="https://api.github.com/repos/mvndaemon/mvnd/releases"
+readonly releases_path="https://api.github.com/repos/apache/maven-mvnd/releases"
 cmd="curl -Ls"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
@@ -13,8 +13,8 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-github_versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sed 's/^v//')
+# Fetch all released versions names, and get only second column. Then remove all unnecessary characters.
+github_versions=$(eval "$cmd" |grep -oE '"name" *: *"[^"]+zip"' | grep -v '\-src' | sed -E -e's/"name" *: *"[^0-9]+-(.+)-[^-]+-[^-]+\.zip"/\1/' -e 's/^v//' | sort -u)
 apache_versions=$(curl -sfL https://downloads.apache.org/maven/mvnd/ | grep -o 'href="[0-9]\+\.[0-9]\+\.[0-9]\+/"' | sed -e 's#^href="\([0-9]*\.[0-9]*\.[0-9]*\)/"#\1#' | sort -u)
 all_versions="$github_versions
 $apache_versions"


### PR DESCRIPTION
fixes #8 

The 1.0-m6 tag contains 2 released mvnd versions: one that target maven 3.9 and another one for maven 4.
The scripts where using the tag name to identify the release but this does not work anymore because of this.

I hacked the shells a bit to use the released zip files names instead of the tag, it is dirty but seems to work...

I also moved the github project from `mvndaemon/mvnd` to `apache/maven-mvnd` everywhere


